### PR TITLE
Add unit tests for Amazon notifications controllers

### DIFF
--- a/wimoor-amazon/amazon-boot/src/test/java/com/wimoor/amazon/notifications/controller/AmzNotificationsControllerTest.java
+++ b/wimoor-amazon/amazon-boot/src/test/java/com/wimoor/amazon/notifications/controller/AmzNotificationsControllerTest.java
@@ -1,0 +1,50 @@
+package com.wimoor.amazon.notifications.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.wimoor.amazon.auth.service.IAmazonAuthorityService;
+import com.wimoor.amazon.notifications.service.IAmzNotificationsDestinationService;
+import com.wimoor.amazon.notifications.service.IAmzNotificationsSubscriptionsService;
+import com.wimoor.common.result.Result;
+
+@ExtendWith(MockitoExtension.class)
+class AmzNotificationsControllerTest {
+
+    @Mock
+    private IAmazonAuthorityService amazonAuthorityService;
+
+    @Mock
+    private IAmzNotificationsDestinationService destinationService;
+
+    @Mock
+    private IAmzNotificationsSubscriptionsService subscriptionsService;
+
+    @InjectMocks
+    private AmzNotificationsController controller;
+
+    @Test
+    void refreshDestinationActionShouldTriggerDestinationTask() {
+        Result<?> result = controller.refreshDestinationAction();
+
+        verify(destinationService).executTask();
+        verifyNoMoreInteractions(destinationService, amazonAuthorityService, subscriptionsService);
+        assertThat(Result.isSuccess(result)).isTrue();
+    }
+
+    @Test
+    void refreshSubscriptionsActionShouldDelegateToAuthorityService() {
+        Result<?> result = controller.refreshSubscriptionsAction();
+
+        verify(amazonAuthorityService).executTask(subscriptionsService);
+        verifyNoMoreInteractions(destinationService, amazonAuthorityService, subscriptionsService);
+        assertThat(Result.isSuccess(result)).isTrue();
+    }
+}

--- a/wimoor-amazon/amazon-boot/src/test/java/com/wimoor/amazon/notifications/controller/AmzNotificationsDestinationControllerTest.java
+++ b/wimoor-amazon/amazon-boot/src/test/java/com/wimoor/amazon/notifications/controller/AmzNotificationsDestinationControllerTest.java
@@ -1,0 +1,35 @@
+package com.wimoor.amazon.notifications.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.wimoor.amazon.notifications.service.IAmzNotificationsDestinationService;
+import com.wimoor.common.result.Result;
+
+@ExtendWith(MockitoExtension.class)
+class AmzNotificationsDestinationControllerTest {
+
+    @Mock
+    private IAmzNotificationsDestinationService destinationService;
+
+    @InjectMocks
+    private AmzNotificationsDestinationController controller;
+
+    @Test
+    void deleteActionShouldDelegateToService() {
+        String destinationId = "dest-123";
+
+        Result<?> result = controller.deleteAction(destinationId);
+
+        verify(destinationService).deleteDestination(destinationId);
+        verifyNoMoreInteractions(destinationService);
+        assertThat(Result.isSuccess(result)).isTrue();
+    }
+}

--- a/wimoor-amazon/amazon-boot/src/test/java/com/wimoor/amazon/notifications/controller/AmzNotificationsSubscriptionsControllerTest.java
+++ b/wimoor-amazon/amazon-boot/src/test/java/com/wimoor/amazon/notifications/controller/AmzNotificationsSubscriptionsControllerTest.java
@@ -1,0 +1,35 @@
+package com.wimoor.amazon.notifications.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.wimoor.amazon.notifications.service.IAmzNotificationsSubscriptionsService;
+import com.wimoor.common.result.Result;
+
+@ExtendWith(MockitoExtension.class)
+class AmzNotificationsSubscriptionsControllerTest {
+
+    @Mock
+    private IAmzNotificationsSubscriptionsService subscriptionsService;
+
+    @InjectMocks
+    private AmzNotificationsSubscriptionsController controller;
+
+    @Test
+    void deleteActionShouldDelegateToService() {
+        String destinationId = "dest-456";
+
+        Result<?> result = controller.deleteAction(destinationId);
+
+        verify(subscriptionsService).deleteSubscriptions(destinationId);
+        verifyNoMoreInteractions(subscriptionsService);
+        assertThat(Result.isSuccess(result)).isTrue();
+    }
+}


### PR DESCRIPTION
## Summary
- add Mockito-based unit tests for the Amazon notifications controllers to verify service interactions and success responses
- cover refresh, delete destination, and delete subscription endpoints to guard regressions

## Testing
- `mvn -q test` *(fails: unresolved com.wimoor internal API artifacts in the module dependency tree)*

------
https://chatgpt.com/codex/tasks/task_e_68d648eaefbc83329423ea0e2078ea31