### PR TITLE
Add static REST controller mapping tests

### DIFF
--- a/wimoor-admin/admin-boot/src/test/java/com/wimoor/admin/RestControllerInterfaceTest.java
+++ b/wimoor-admin/admin-boot/src/test/java/com/wimoor/admin/RestControllerInterfaceTest.java
@@ -1,0 +1,75 @@
+package com.wimoor.admin;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Static verification ensuring each REST controller exposes at least one request mapping.
+ */
+public class RestControllerInterfaceTest {
+
+    @Test
+    void allRestControllersExposeRequestMappings() throws IOException {
+        Path sourceRoot = Paths.get("src/main/java");
+        assertTrue(Files.exists(sourceRoot), "Source directory not found: " + sourceRoot.toAbsolutePath());
+
+        try (Stream<Path> pathStream = Files.walk(sourceRoot)) {
+            List<SourceFile> restControllers = pathStream
+                .filter(path -> path.toString().endsWith(".java"))
+                .map(path -> new SourceFile(path, readContent(path)))
+                .filter(SourceFile::isRestController)
+                .collect(Collectors.toList());
+
+            List<String> missingMappings = new ArrayList<>();
+            for (SourceFile controller : restControllers) {
+                if (!containsAnyMappingAnnotation(controller.content)) {
+                    missingMappings.add(sourceRoot.relativize(controller.path).toString());
+                }
+            }
+
+            assertTrue(missingMappings.isEmpty(), "Controllers missing request mapping annotations: " + missingMappings);
+        }
+    }
+
+    private static String readContent(Path file) {
+        try {
+            return new String(Files.readAllBytes(file), StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to read file " + file, e);
+        }
+    }
+
+    private static boolean containsAnyMappingAnnotation(String content) {
+        return content.contains("@RequestMapping")
+            || content.contains("@GetMapping")
+            || content.contains("@PostMapping")
+            || content.contains("@PutMapping")
+            || content.contains("@DeleteMapping")
+            || content.contains("@PatchMapping");
+    }
+
+    private static class SourceFile {
+        private final Path path;
+        private final String content;
+
+        private SourceFile(Path path, String content) {
+            this.path = path;
+            this.content = content;
+        }
+
+        private boolean isRestController() {
+            return content.contains("@RestController") && !content.contains("@RestControllerAdvice");
+        }
+    }
+}

--- a/wimoor-amazon-adv/amazon-adv-boot/src/test/java/com/wimoor/amazon/adv/RestControllerInterfaceTest.java
+++ b/wimoor-amazon-adv/amazon-adv-boot/src/test/java/com/wimoor/amazon/adv/RestControllerInterfaceTest.java
@@ -1,0 +1,72 @@
+package com.wimoor.amazon.adv;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+
+public class RestControllerInterfaceTest {
+
+    @Test
+    void allRestControllersExposeRequestMappings() throws IOException {
+        Path sourceRoot = Paths.get("src/main/java");
+        assertTrue(Files.exists(sourceRoot), "Source directory not found: " + sourceRoot.toAbsolutePath());
+
+        try (Stream<Path> pathStream = Files.walk(sourceRoot)) {
+            List<SourceFile> restControllers = pathStream
+                .filter(path -> path.toString().endsWith(".java"))
+                .map(path -> new SourceFile(path, readContent(path)))
+                .filter(SourceFile::isRestController)
+                .collect(Collectors.toList());
+
+            List<String> missingMappings = new ArrayList<>();
+            for (SourceFile controller : restControllers) {
+                if (!containsAnyMappingAnnotation(controller.content)) {
+                    missingMappings.add(sourceRoot.relativize(controller.path).toString());
+                }
+            }
+
+            assertTrue(missingMappings.isEmpty(), "Controllers missing request mapping annotations: " + missingMappings);
+        }
+    }
+
+    private static String readContent(Path file) {
+        try {
+            return new String(Files.readAllBytes(file), StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to read file " + file, e);
+        }
+    }
+
+    private static boolean containsAnyMappingAnnotation(String content) {
+        return content.contains("@RequestMapping")
+            || content.contains("@GetMapping")
+            || content.contains("@PostMapping")
+            || content.contains("@PutMapping")
+            || content.contains("@DeleteMapping")
+            || content.contains("@PatchMapping");
+    }
+
+    private static class SourceFile {
+        private final Path path;
+        private final String content;
+
+        private SourceFile(Path path, String content) {
+            this.path = path;
+            this.content = content;
+        }
+
+        private boolean isRestController() {
+            return content.contains("@RestController") && !content.contains("@RestControllerAdvice");
+        }
+    }
+}

--- a/wimoor-amazon/amazon-boot/src/test/java/com/wimoor/amazon/RestControllerInterfaceTest.java
+++ b/wimoor-amazon/amazon-boot/src/test/java/com/wimoor/amazon/RestControllerInterfaceTest.java
@@ -1,0 +1,72 @@
+package com.wimoor.amazon;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+
+public class RestControllerInterfaceTest {
+
+    @Test
+    void allRestControllersExposeRequestMappings() throws IOException {
+        Path sourceRoot = Paths.get("src/main/java");
+        assertTrue(Files.exists(sourceRoot), "Source directory not found: " + sourceRoot.toAbsolutePath());
+
+        try (Stream<Path> pathStream = Files.walk(sourceRoot)) {
+            List<SourceFile> restControllers = pathStream
+                .filter(path -> path.toString().endsWith(".java"))
+                .map(path -> new SourceFile(path, readContent(path)))
+                .filter(SourceFile::isRestController)
+                .collect(Collectors.toList());
+
+            List<String> missingMappings = new ArrayList<>();
+            for (SourceFile controller : restControllers) {
+                if (!containsAnyMappingAnnotation(controller.content)) {
+                    missingMappings.add(sourceRoot.relativize(controller.path).toString());
+                }
+            }
+
+            assertTrue(missingMappings.isEmpty(), "Controllers missing request mapping annotations: " + missingMappings);
+        }
+    }
+
+    private static String readContent(Path file) {
+        try {
+            return new String(Files.readAllBytes(file), StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to read file " + file, e);
+        }
+    }
+
+    private static boolean containsAnyMappingAnnotation(String content) {
+        return content.contains("@RequestMapping")
+            || content.contains("@GetMapping")
+            || content.contains("@PostMapping")
+            || content.contains("@PutMapping")
+            || content.contains("@DeleteMapping")
+            || content.contains("@PatchMapping");
+    }
+
+    private static class SourceFile {
+        private final Path path;
+        private final String content;
+
+        private SourceFile(Path path, String content) {
+            this.path = path;
+            this.content = content;
+        }
+
+        private boolean isRestController() {
+            return content.contains("@RestController") && !content.contains("@RestControllerAdvice");
+        }
+    }
+}

--- a/wimoor-common/common-feishu/src/test/java/com/wimoor/feishu/RestControllerInterfaceTest.java
+++ b/wimoor-common/common-feishu/src/test/java/com/wimoor/feishu/RestControllerInterfaceTest.java
@@ -1,0 +1,72 @@
+package com.wimoor.feishu;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+
+public class RestControllerInterfaceTest {
+
+    @Test
+    void allRestControllersExposeRequestMappings() throws IOException {
+        Path sourceRoot = Paths.get("src/main/java");
+        assertTrue(Files.exists(sourceRoot), "Source directory not found: " + sourceRoot.toAbsolutePath());
+
+        try (Stream<Path> pathStream = Files.walk(sourceRoot)) {
+            List<SourceFile> restControllers = pathStream
+                .filter(path -> path.toString().endsWith(".java"))
+                .map(path -> new SourceFile(path, readContent(path)))
+                .filter(SourceFile::isRestController)
+                .collect(Collectors.toList());
+
+            List<String> missingMappings = new ArrayList<>();
+            for (SourceFile controller : restControllers) {
+                if (!containsAnyMappingAnnotation(controller.content)) {
+                    missingMappings.add(sourceRoot.relativize(controller.path).toString());
+                }
+            }
+
+            assertTrue(missingMappings.isEmpty(), "Controllers missing request mapping annotations: " + missingMappings);
+        }
+    }
+
+    private static String readContent(Path file) {
+        try {
+            return new String(Files.readAllBytes(file), StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to read file " + file, e);
+        }
+    }
+
+    private static boolean containsAnyMappingAnnotation(String content) {
+        return content.contains("@RequestMapping")
+            || content.contains("@GetMapping")
+            || content.contains("@PostMapping")
+            || content.contains("@PutMapping")
+            || content.contains("@DeleteMapping")
+            || content.contains("@PatchMapping");
+    }
+
+    private static class SourceFile {
+        private final Path path;
+        private final String content;
+
+        private SourceFile(Path path, String content) {
+            this.path = path;
+            this.content = content;
+        }
+
+        private boolean isRestController() {
+            return content.contains("@RestController") && !content.contains("@RestControllerAdvice");
+        }
+    }
+}

--- a/wimoor-erp/erp-boot/src/test/java/com/wimoor/erp/RestControllerInterfaceTest.java
+++ b/wimoor-erp/erp-boot/src/test/java/com/wimoor/erp/RestControllerInterfaceTest.java
@@ -1,0 +1,72 @@
+package com.wimoor.erp;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+
+public class RestControllerInterfaceTest {
+
+    @Test
+    void allRestControllersExposeRequestMappings() throws IOException {
+        Path sourceRoot = Paths.get("src/main/java");
+        assertTrue(Files.exists(sourceRoot), "Source directory not found: " + sourceRoot.toAbsolutePath());
+
+        try (Stream<Path> pathStream = Files.walk(sourceRoot)) {
+            List<SourceFile> restControllers = pathStream
+                .filter(path -> path.toString().endsWith(".java"))
+                .map(path -> new SourceFile(path, readContent(path)))
+                .filter(SourceFile::isRestController)
+                .collect(Collectors.toList());
+
+            List<String> missingMappings = new ArrayList<>();
+            for (SourceFile controller : restControllers) {
+                if (!containsAnyMappingAnnotation(controller.content)) {
+                    missingMappings.add(sourceRoot.relativize(controller.path).toString());
+                }
+            }
+
+            assertTrue(missingMappings.isEmpty(), "Controllers missing request mapping annotations: " + missingMappings);
+        }
+    }
+
+    private static String readContent(Path file) {
+        try {
+            return new String(Files.readAllBytes(file), StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to read file " + file, e);
+        }
+    }
+
+    private static boolean containsAnyMappingAnnotation(String content) {
+        return content.contains("@RequestMapping")
+            || content.contains("@GetMapping")
+            || content.contains("@PostMapping")
+            || content.contains("@PutMapping")
+            || content.contains("@DeleteMapping")
+            || content.contains("@PatchMapping");
+    }
+
+    private static class SourceFile {
+        private final Path path;
+        private final String content;
+
+        private SourceFile(Path path, String content) {
+            this.path = path;
+            this.content = content;
+        }
+
+        private boolean isRestController() {
+            return content.contains("@RestController") && !content.contains("@RestControllerAdvice");
+        }
+    }
+}

--- a/wimoor-quote/quote-boot/src/test/java/com/wimoor/quote/RestControllerInterfaceTest.java
+++ b/wimoor-quote/quote-boot/src/test/java/com/wimoor/quote/RestControllerInterfaceTest.java
@@ -1,0 +1,72 @@
+package com.wimoor.quote;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+
+public class RestControllerInterfaceTest {
+
+    @Test
+    void allRestControllersExposeRequestMappings() throws IOException {
+        Path sourceRoot = Paths.get("src/main/java");
+        assertTrue(Files.exists(sourceRoot), "Source directory not found: " + sourceRoot.toAbsolutePath());
+
+        try (Stream<Path> pathStream = Files.walk(sourceRoot)) {
+            List<SourceFile> restControllers = pathStream
+                .filter(path -> path.toString().endsWith(".java"))
+                .map(path -> new SourceFile(path, readContent(path)))
+                .filter(SourceFile::isRestController)
+                .collect(Collectors.toList());
+
+            List<String> missingMappings = new ArrayList<>();
+            for (SourceFile controller : restControllers) {
+                if (!containsAnyMappingAnnotation(controller.content)) {
+                    missingMappings.add(sourceRoot.relativize(controller.path).toString());
+                }
+            }
+
+            assertTrue(missingMappings.isEmpty(), "Controllers missing request mapping annotations: " + missingMappings);
+        }
+    }
+
+    private static String readContent(Path file) {
+        try {
+            return new String(Files.readAllBytes(file), StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to read file " + file, e);
+        }
+    }
+
+    private static boolean containsAnyMappingAnnotation(String content) {
+        return content.contains("@RequestMapping")
+            || content.contains("@GetMapping")
+            || content.contains("@PostMapping")
+            || content.contains("@PutMapping")
+            || content.contains("@DeleteMapping")
+            || content.contains("@PatchMapping");
+    }
+
+    private static class SourceFile {
+        private final Path path;
+        private final String content;
+
+        private SourceFile(Path path, String content) {
+            this.path = path;
+            this.content = content;
+        }
+
+        private boolean isRestController() {
+            return content.contains("@RestController") && !content.contains("@RestControllerAdvice");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add JUnit tests in each REST-heavy module that scan controller sources to ensure every `@RestController` declares at least one request mapping annotation

## Testing
- `mvn -pl wimoor-admin/admin-boot test` *(fails: missing internal modules published to Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68d648dd4cc88332863fa23d1eff4fb2